### PR TITLE
pkg-norecs: removed non-existent packages.

### DIFF
--- a/pkgs-norecs
+++ b/pkgs-norecs
@@ -92,8 +92,6 @@ intel-microcode
 #jfsutils
 lame
 libinput-tools
-libinput-list-devices
-libinput-debug-events
 libpam-gnome-keyring
 libreoffice-writer
 libnotify-bin


### PR DESCRIPTION
There are no packages by those names, the *libinput-tools* package contains man pages for both of those commands though.